### PR TITLE
Organize Dockerfile better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,13 @@ ENV PATH ${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin
 ARG 3.24.3
 RUN git clone --branch stable https://github.com/flutter/flutter.git ${FLUTTER_HOME}
 
-
 RUN yes | flutter doctor --android-licenses \
-    && flutter doctor \
+    && flutter doctor -v \
     && chown -R root:root ${FLUTTER_HOME}
-    
-# RUN sudo apt-get update \
-#     && sudo apt-get install -y chromium-browser \
-#     && sudo rm -rf /var/lib/apt/lists/*
-    
-RUN flutter doctor -v
 
-#Install Firebase Tools:
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip \
+    && apt-get install -y chromium-browser \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g firebase-tools@8.0.3
-
-
-#Install Python
-
-RUN apt-get update
-RUN apt-get install -y python3
-RUN apt-get install -y python3-pip


### PR DESCRIPTION
Organize the `Dockerfile` to improve build performance and reduce image size.

* Combine `flutter doctor` commands into a single `RUN` command.
* Combine `apt-get update` and `apt-get install` commands into a single `RUN` command.
* Remove commented-out code.
* Specify exact versions for dependencies.

